### PR TITLE
Enable all 5 user FS endpoints on F446xx MCUs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ riscv = { version = "0.5.4", optional = true }
 cortex-m = { version = "0.6.0", optional = true }
 vcell = "0.1.0"
 usb-device = "0.2.2"
-stm32ral = { version = "0.3.1", features = ["stm32f429"] }
+stm32ral = { version = "0.4.1" }
 
 [package.metadata.docs.rs]
 features = ['cortex-m', 'fs']
@@ -22,6 +22,7 @@ features = ['cortex-m', 'fs']
 [features]
 hs = []
 fs = []
-stm32f429xx = ['cortex-m']
+stm32f446xx = ['cortex-m', 'stm32ral/stm32f446']
+stm32f429xx = ['cortex-m', 'stm32ral/stm32f429']
 stm32f401xx = ['cortex-m', 'fs']
 gd32vf103xx = ['riscv', 'fs']

--- a/src/endpoint_memory.rs
+++ b/src/endpoint_memory.rs
@@ -5,6 +5,12 @@ use crate::target::fifo_read_into;
 use usb_device::{Result, UsbError};
 use crate::ral::otg_fifo::FIFO_DEPTH_WORDS;
 
+#[cfg(not(feature = "stm32f446xx"))]
+const N_ENDPOINTS: usize = 4;
+
+#[cfg(feature = "stm32f446xx")]
+const N_ENDPOINTS: usize = 6;
+
 #[derive(Eq, PartialEq)]
 pub enum EndpointBufferState {
     Empty,
@@ -110,7 +116,7 @@ pub struct EndpointMemoryAllocator {
     next_free_offset: usize,
     max_size_words: usize,
     memory: &'static mut [u32],
-    tx_fifo_size_words: [u16; 4],
+    tx_fifo_size_words: [u16; N_ENDPOINTS],
 }
 
 impl EndpointMemoryAllocator {
@@ -119,7 +125,7 @@ impl EndpointMemoryAllocator {
             next_free_offset: 0,
             max_size_words: 0,
             memory,
-            tx_fifo_size_words: [0; 4],
+            tx_fifo_size_words: [0; N_ENDPOINTS],
         }
     }
 


### PR DESCRIPTION
The F446 USB FS peripheral has 5 endpoints, however only 3 are currently available. This patch exposes the remaining 2 endpoints for F446 units. So far I have not been able to test using all 5 endpoints at the same time, however setting it up as a basic device does enumerate.

Please let me know if I missed anything, and perhaps I should think about adding some default features to `Cargo.toml` that assume the F429?