### PR TITLE
Add product_id value = 0x0000_2300 (used on STM32H7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ started by [@mvirkkunen](https://github.com/mvirkkunen).
 * `STM32F401xx`
 * `STM32F446xx` (OTG_FS and OTG_HS in FS mode)
 * `STM32F723xx` (OTG_FS)
+* `STM32H7xxxx` (OTG_HS1 in FS mode)
 * And others...
 
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -313,7 +313,7 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
 
                     modify_reg!(otg_global, regs.global, GCCFG, VBUSASEN: 0, VBUSBSEN: 0, SOFOUTEN: 0);
                 }
-                0x0000_2000 | 0x0000_2100 | 0x0000_3000 | 0x0000_3100 => {
+                0x0000_2000 | 0x0000_2100 | 0x0000_2300 | 0x0000_3000 | 0x0000_3100 => {
                     // F446-like chips have the GCCFG.VBDEN bit with the opposite meaning
 
                     //modify_reg!(otg_global, regs.global, GCCFG, VBDEN: 0);
@@ -504,6 +504,7 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
 
                                 // Re-enable the endpoint, F446-like chips only
                                 if core_id == 0x0000_2000 || core_id == 0x0000_2100 ||
+                                   core_id == 0x0000_2300 ||
                                    core_id == 0x0000_3000 || core_id == 0x0000_3100 {
                                     let ep = endpoint_out::instance(epnum as u8);
                                     modify_reg!(endpoint_out, ep, DOEPCTL, CNAK: 1, EPENA: 1);


### PR DESCRIPTION
As found in the core_id register. This is enough to get the H7 working with the usbd-serial CDC-ACM implementation.

The main differences between this revision and 0x0000_2100:

* Add scatter-gather DMA
* Add battery charging detection

Neither of those features are used in this crate, so there's no changes to make.