### PR TITLE
Update cortex-m to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["no-std", "embedded", "usb"]
 
 [dependencies]
 riscv = { version = "0.5.4", optional = true }
-cortex-m = { version = "0.6.0", optional = true }
+cortex-m = { version = "0.7", optional = true }
 embedded-hal = "0.2"
 vcell = "0.1.0"
 usb-device = "0.2.2"


### PR DESCRIPTION
`cortex-m` v0.6.5+ [are forward-compatible](https://github.com/rust-embedded/cortex-m/blob/master/CHANGELOG.md#v065---2021-01-24) with `cortex-m` v0.7.0+, so this should be fine as a point release.