### PR TITLE
Add support for external ULPI PHY, and add helpers for ULPI register read/write

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ started by [@mvirkkunen](https://github.com/mvirkkunen).
 * `STM32F401xx`
 * `STM32F446xx` (OTG_FS and OTG_HS in FS mode)
 * `STM32F723xx` (OTG_FS and OTG_HS with internal HS PHY)
-* `STM32H7xxxx` (OTG1_HS and OTG2_HS in FS mode)
+* `STM32H7xxxx` (OTG1_HS and OTG2_HS in FS mode, and OTG1_HS with external HS PHY)
 * And others...
 
 
@@ -27,7 +27,7 @@ This trait declares all the peripheral properties that may vary from one device 
 Additionally, hal should pass `fs` of `hs` feature to the `synopsys-usb-otg` library to
 define a peripheral type:
 * `fs` - for FullSpeed peripherals
-* `hs` - for HighSpeed peripherals (only internal PHY is supported)
+* `hs` - for HighSpeed peripherals
 
 Only one peripheral type can be selected at the moment.
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -292,7 +292,7 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                         PHYSEL: 0 // ULPI or UTMI
                     );
 
-                    // Select vbus source
+                    // Select VBUS source
                     modify_reg!(otg_global, regs.global(), GUSBCFG,
                         ULPIEVBUSD: 0,
                         ULPIEVBUSI: 0
@@ -309,7 +309,23 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
 
                     self.peripheral.setup_internal_hs_phy();
                 }
-                PhyType::ExternalHighSpeed => unimplemented!()
+                PhyType::ExternalHighSpeed => {
+                    // Turn off embedded PHY
+                    modify_reg!(otg_global, regs.global(), GCCFG, PWRDWN: 0);
+
+                    // Init The ULPI Interface
+                    modify_reg!(otg_global, regs.global(), GUSBCFG,
+                        TSDPS: 0,
+                        ULPIFSLS: 0,
+                        PHYSEL: 0 // ULPI or UTMI
+                    );
+
+                    // Select VBUS source
+                    modify_reg!(otg_global, regs.global(), GUSBCFG,
+                        ULPIEVBUSD: 0,
+                        ULPIEVBUSI: 0
+                    );
+                }
             }
 
             // Perform core soft-reset

--- a/src/ral/instances/otg_hs_global.rs
+++ b/src/ral/instances/otg_hs_global.rs
@@ -8,7 +8,7 @@
 pub use super::super::peripherals::otg_hs_global::Instance;
 pub use super::super::peripherals::otg_hs_global::{RegisterBlock, ResetValues};
 pub use super::super::peripherals::otg_hs_global::{
-    CID, DIEPTXF1, DIEPTXF2, DIEPTXF3, DIEPTXF4, DIEPTXF5, GAHBCFG, GCCFG, GINTMSK, GINTSTS,
+    CID, DIEPTXF1, DIEPTXF2, DIEPTXF3, DIEPTXF4, DIEPTXF5, GAHBCFG, PHYCR, GCCFG, GINTMSK, GINTSTS,
     GNPTXFSIZ, GNPTXSTS, GOTGCTL, GOTGINT, GRSTCTL, GRXFSIZ, GRXSTSP, GRXSTSR, GUSBCFG, HPTXFSIZ,
 };
 
@@ -39,6 +39,7 @@ pub mod OTG_HS_GLOBAL {
         GRXFSIZ: 0x00000200,
         GNPTXFSIZ: 0x00000200,
         GNPTXSTS: 0x00080200,
+        PHYCR: 0x00000000,
         GCCFG: 0x00000000,
         CID: 0x00001200,
         HPTXFSIZ: 0x02000600,

--- a/src/ral/peripherals/otg_hs_global.rs
+++ b/src/ral/peripherals/otg_hs_global.rs
@@ -1650,6 +1650,94 @@ pub mod GNPTXSTS {
     }
 }
 
+/// OTG_HS PHY Control Register
+pub mod PHYCR {
+
+    /// Data
+    pub mod DATA {
+        /// Offset (0 bits)
+        pub const offset: u32 = 0;
+        /// Mask (8 bits: 0xff << 0)
+        pub const mask: u32 = 0xff << offset;
+        /// Read-only values (empty)
+        pub mod R {}
+        /// Write-only values (empty)
+        pub mod W {}
+        /// Read-write values (empty)
+        pub mod RW {}
+    }
+
+    /// Address
+    pub mod ADDR {
+        /// Offset (16 bits)
+        pub const offset: u32 = 16;
+        /// Mask (8 bits: 0xff << 16)
+        pub const mask: u32 = 0xff << offset;
+        /// Read-only values (empty)
+        pub mod R {}
+        /// Write-only values (empty)
+        pub mod W {}
+        /// Read-write values (empty)
+        pub mod RW {}
+    }
+
+    /// Read/Write control
+    pub mod RW {
+        /// Offset (22 bits)
+        pub const offset: u32 = 22;
+        /// Mask (1 bit: 1 << 22)
+        pub const mask: u32 = 1 << offset;
+        /// Read-only values (empty)
+        pub mod R {}
+        /// Write-only values (empty)
+        pub mod W {}
+        /// Read-write values (empty)
+        pub mod RW {}
+    }
+
+    /// New Read/Write transaction start
+    pub mod NEW {
+        /// Offset (25 bits)
+        pub const offset: u32 = 25;
+        /// Mask (1 bit: 1 << 25)
+        pub const mask: u32 = 1 << offset;
+        /// Read-only values (empty)
+        pub mod R {}
+        /// Write-only values (empty)
+        pub mod W {}
+        /// Read-write values (empty)
+        pub mod RW {}
+    }
+
+    /// Busy status flag
+    pub mod BUSY {
+        /// Offset (26 bits)
+        pub const offset: u32 = 26;
+        /// Mask (1 bit: 1 << 26)
+        pub const mask: u32 = 1 << offset;
+        /// Read-only values (empty)
+        pub mod R {}
+        /// Write-only values (empty)
+        pub mod W {}
+        /// Read-write values (empty)
+        pub mod RW {}
+    }
+
+    /// Done status flag
+    pub mod DONE {
+        /// Offset (27 bits)
+        pub const offset: u32 = 27;
+        /// Mask (1 bit: 1 << 27)
+        pub const mask: u32 = 1 << offset;
+        /// Read-only values (empty)
+        pub mod R {}
+        /// Write-only values (empty)
+        pub mod W {}
+        /// Read-write values (empty)
+        pub mod RW {}
+    }
+}
+
 /// OTG_HS general core configuration register
 pub mod GCCFG {
 
@@ -1886,7 +1974,10 @@ pub struct RegisterBlock {
     /// OTG_HS nonperiodic transmit FIFO/queue status register
     pub GNPTXSTS: RORegister<u32>,
 
-    _reserved1: [u32; 2],
+    _reserved1: u32,
+
+    /// OTG_HS PHY Control Register
+    pub PHYCR: RWRegister<u32>,
 
     /// OTG_HS general core configuration register
     pub GCCFG: RWRegister<u32>,
@@ -1927,6 +2018,7 @@ pub struct ResetValues {
     pub GRXFSIZ: u32,
     pub GNPTXFSIZ: u32,
     pub GNPTXSTS: u32,
+    pub PHYCR: u32,
     pub GCCFG: u32,
     pub CID: u32,
     pub HPTXFSIZ: u32,


### PR DESCRIPTION
Tested on a STM32H743BIT6 with a USB3300-EZK.

PHYCR is an undocumented register for communicating with a ULPI PHY. The only available information is in a few [STM32Cube firmware packages](https://github.com/STMicroelectronics/STM32CubeF7/blob/3600603267ebc7da619f50542e99bbdfd7e35f4a/Projects/STM32746G-Discovery/Examples/PWR/PWR_CurrentConsumption/Src/stm32f7xx_lp_modes.c#L446-L486). I've added `ulpi_read` and `ulpi_write` as helpers for  These functions are useful for enabling low power modes, enabling USB Audio mode, changing transmit power or receive squelch levels, etc.