### PR TITLE
Fix Tx FIFO memory calculation

### DIFF
--- a/src/endpoint_memory.rs
+++ b/src/endpoint_memory.rs
@@ -153,7 +153,7 @@ impl<USB: UsbPeripheral> EndpointMemoryAllocator<USB> {
         }
 
         let mut used = self.total_rx_buffer_size_words() as usize + 30;
-        for sz in &self.tx_fifo_size_words {
+        for sz in &self.tx_fifo_size_words[0..ep_number] {
             used += core::cmp::max(*sz as usize, 16);
         }
         used -= 16;

--- a/src/endpoint_memory.rs
+++ b/src/endpoint_memory.rs
@@ -152,11 +152,9 @@ impl<USB: UsbPeripheral> EndpointMemoryAllocator<USB> {
             return Err(UsbError::InvalidEndpoint)
         }
 
-        let mut used = self.total_rx_buffer_size_words() as usize + 30;
-        for sz in &self.tx_fifo_size_words[0..ep_number] {
-            used += core::cmp::max(*sz as usize, 16);
-        }
-        used -= 16;
+        let used = 30
+            + self.total_rx_buffer_size_words() as usize
+            + self.tx_fifo_size_words.iter().sum::<u16>() as usize;
 
         let size_words = core::cmp::max((size + 3) / 4, 16);
         if (used + size_words) > USB::FIFO_DEPTH_WORDS {


### PR DESCRIPTION
This used to allocate 8 * 16 words minimum, no matter how many Tx endpoints where active. This was because `tx_fifo_size_words` is set to `[0; 9]` in `new`. Now we only account for memory allocated to enabled Tx endpoints when determining how much has already been used by limiting the elements we consider to those before the current endpoint being allocated.