### PR TITLE
[WIP] Isochronous transfer support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ vcell = "0.1.0"
 usb-device = "0.2.3"
 
 [patch.crates-io]
-usb-device = { path = "../usb-device" }
+usb-device = { git = "https://github.com/dgoodlad/usb-device", branch = "crabdac" }
 
 [package.metadata.docs.rs]
 features = ['cortex-m', 'fs']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ embedded-hal = "0.2.4"
 vcell = "0.1.0"
 usb-device = "0.2.3"
 
+[patch.crates-io]
+usb-device = { path = "../usb-device" }
+
 [package.metadata.docs.rs]
 features = ['cortex-m', 'fs']
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -431,13 +431,6 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                 }
             }
 
-            // Delay a few cycles after selecting PHY before doing a core reset
-            // https://community.st.com/s/question/0D53W00000znL7jSAE/stm32h745-usbotg-intermittently-fails-to-respond-to-core-reset
-            #[cfg(not(feature = "cortex-m"))]
-            for _ in 0..500000 {};
-            #[cfg(feature = "cortex-m")]
-            cortex_m::asm::delay(25600);
-
             // Perform core soft-reset
             while read_reg!(otg_global, regs.global(), GRSTCTL, AHBIDL) == 0 {}
             modify_reg!(otg_global, regs.global(), GRSTCTL, CSRST: 1);

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -431,6 +431,13 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                 }
             }
 
+            // Delay a few cycles after selecting PHY before doing a core reset
+            // https://community.st.com/s/question/0D53W00000znL7jSAE/stm32h745-usbotg-intermittently-fails-to-respond-to-core-reset
+            #[cfg(not(feature = "cortex-m"))]
+            for _ in 0..500000 {};
+            #[cfg(feature = "cortex-m")]
+            cortex_m::asm::delay(25600);
+
             // Perform core soft-reset
             while read_reg!(otg_global, regs.global(), GRSTCTL, AHBIDL) == 0 {}
             modify_reg!(otg_global, regs.global(), GRSTCTL, CSRST: 1);

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -498,7 +498,8 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
             write_reg!(otg_global, regs.global(), GINTMSK,
                 USBRST: 1, ENUMDNEM: 1,
                 USBSUSPM: 1, WUIM: 1,
-                IEPINT: 1, RXFLVLM: 1
+                IEPINT: 1, RXFLVLM: 1,
+                SOFM: 1
             );
 
             // clear pending interrupts

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -498,8 +498,7 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
             write_reg!(otg_global, regs.global(), GINTMSK,
                 USBRST: 1, ENUMDNEM: 1,
                 USBSUSPM: 1, WUIM: 1,
-                IEPINT: 1, RXFLVLM: 1,
-                SOFM: 1
+                IEPINT: 1, RXFLVLM: 1
             );
 
             // clear pending interrupts

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -498,7 +498,8 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
             write_reg!(otg_global, regs.global(), GINTMSK,
                 USBRST: 1, ENUMDNEM: 1,
                 USBSUSPM: 1, WUIM: 1,
-                IEPINT: 1, RXFLVLM: 1
+                IEPINT: 1, RXFLVLM: 1,
+                IISOIXFRM: 1
             );
 
             // clear pending interrupts
@@ -585,8 +586,8 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
 
             let core_id = read_reg!(otg_global, regs.global(), CID);
 
-            let (wakeup, suspend, enum_done, reset, iep, rxflvl) = read_reg!(otg_global, regs.global(), GINTSTS,
-                WKUPINT, USBSUSP, ENUMDNE, USBRST, IEPINT, RXFLVL
+            let (wakeup, suspend, enum_done, reset, iep, rxflvl, iisoixfr) = read_reg!(otg_global, regs.global(), GINTSTS,
+                WKUPINT, USBSUSP, ENUMDNE, USBRST, IEPINT, RXFLVL, IISOIXFR
             );
 
             if reset != 0 {
@@ -649,6 +650,53 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                 write_reg!(otg_global, regs.global(), GINTSTS, USBSUSP: 1);
 
                 PollResult::Suspend
+            } else if iisoixfr != 0 {
+                use crate::ral::endpoint_in;
+
+                // Incomplete isochronous IN transfer; see
+                // RM0383 Rev 3 pp797 "Incomplete isochronous IN data transfers"
+                write_reg!(otg_global, regs.global(), GINTSTS, IISOIXFR: 1);
+
+                let in_endpoints = self.allocator.endpoints_in
+                                                  .iter()
+                                                  .flatten()
+                                                  .map(|ep| ep.address().index());
+
+                let mut iep: u16 = 0;
+
+                for epnum in in_endpoints {
+                    let ep_regs = regs.endpoint_in(epnum);
+
+                    // filter out non-isochronous endpoints
+                    if read_reg!(endpoint_in, ep_regs, DIEPCTL, EPTYP) & 0x11 != 0x01 { continue; }
+
+                    // identify incomplete transfers by the presence of the NAK event
+                    // see RM0383 Rev 3 pp 746 description of NAK:
+                    //
+                    // > In case of isochronous IN endpoints the interrupt gets
+                    // > generated when a zero length packet is transmitted due
+                    // > to unavailability of data in the Tx FIFO.
+                    if read_reg!(endpoint_in, ep_regs, DIEPINT) & 1<<13 == 0 { continue; }
+
+                    // Set NAK
+                    modify_reg!(endpoint_in, ep_regs, DIEPCTL, SNAK: 1);
+                    while read_reg!(endpoint_in, ep_regs, DIEPINT, INEPNE) == 0 {}
+
+                    // Disable the endpoint
+                    modify_reg!(endpoint_in, ep_regs, DIEPCTL, SNAK: 1, EPDIS: 1);
+                    while read_reg!(endpoint_in, ep_regs, DIEPINT, EPDISD) == 0 {}
+                    modify_reg!(endpoint_in, ep_regs, DIEPINT, EPDISD: 1);
+                    assert!(read_reg!(endpoint_in, ep_regs, DIEPCTL, EPENA) == 0);
+                    assert!(read_reg!(endpoint_in, ep_regs, DIEPCTL, EPDIS) == 0);
+
+                    // Flush the TX FIFO
+                    modify_reg!(otg_global, regs.global(), GRSTCTL, TXFNUM: epnum as u32, TXFFLSH: 1);
+                    while read_reg!(otg_global, regs.global(), GRSTCTL, TXFFLSH) == 1 {}
+
+                    iep |= 1 << epnum;
+                }
+
+                PollResult::Data { ep_out: 0, ep_in_complete: iep, ep_setup: 0 }
             } else {
                 let mut ep_out = 0;
                 let mut ep_in_complete = 0;

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -93,7 +93,7 @@ impl EndpointIn {
             write_reg!(endpoint_in, regs, DIEPCTL,
                 SNAK: 1,
                 USBAEP: 1,
-                EPTYP: self.descriptor.ep_type as u32,
+                EPTYP: self.descriptor.ep_type.to_bm_attributes() as u32,
                 SD0PID_SEVNFRM: 1,
                 TXFNUM: self.index() as u32,
                 MPSIZ: self.descriptor.max_packet_size as u32
@@ -202,7 +202,7 @@ impl EndpointOut {
                 CNAK: 1,
                 EPENA: 1,
                 USBAEP: 1,
-                EPTYP: self.descriptor.ep_type as u32,
+                EPTYP: self.descriptor.ep_type.to_bm_attributes() as u32,
                 MPSIZ: self.descriptor.max_packet_size as u32
             );
         }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -152,7 +152,7 @@ impl EndpointIn {
             EndpointType::Isochronous(_) => {
                 // Previous frame number is OTG_DSTS.FNSOF
                 let frame_number = read_reg!(otg_device, device, DSTS, FNSOF);
-                if frame_number & 0x1 == 1 {
+                if frame_number & 0x1 == 0 {
                     // Previous frame number is odd, so upcoming frame is even
                     modify_reg!(endpoint_in, ep, DIEPCTL, SD0PID_SEVNFRM: 1);
                 } else {

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -144,8 +144,6 @@ impl EndpointIn {
         #[cfg(feature = "hs")]
         write_reg!(endpoint_in, ep, DIEPTSIZ, MCNT: 1, PKTCNT: 1, XFRSIZ: buf.len() as u32);
 
-        modify_reg!(endpoint_in, ep, DIEPCTL, CNAK: 1, EPENA: 1);
-
         match self.descriptor.ep_type {
             // Isochronous endpoints must set the correct even/odd frame bit to
             // correspond with the next frame's number.
@@ -162,6 +160,8 @@ impl EndpointIn {
             },
             _ => {}
         }
+
+        modify_reg!(endpoint_in, ep, DIEPCTL, CNAK: 1, EPENA: 1);
 
         fifo_write(self.usb, self.index(), buf);
 

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -155,6 +155,9 @@ impl EndpointIn {
                     modify_reg!(endpoint_in, ep, DIEPCTL, SD0PID_SEVNFRM: 1);
                 } else {
                     // Previous frame number is even, so upcoming frame is odd
+                    #[cfg(feature = "fs")]
+                    modify_reg!(endpoint_in, ep, DIEPCTL, SODDFRM_SD1PID: 1);
+                    #[cfg(feature = "hs")]
                     modify_reg!(endpoint_in, ep, DIEPCTL, SODDFRM: 1);
                 }
             },

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -150,7 +150,7 @@ impl EndpointIn {
             EndpointType::Isochronous(_) => {
                 // Previous frame number is OTG_DSTS.FNSOF
                 let frame_number = read_reg!(otg_device, device, DSTS, FNSOF);
-                if frame_number & 0x1 == 0 {
+                if frame_number & 0x1 == 1 {
                     // Previous frame number is odd, so upcoming frame is even
                     modify_reg!(endpoint_in, ep, DIEPCTL, SD0PID_SEVNFRM: 1);
                 } else {

--- a/src/endpoint_memory.rs
+++ b/src/endpoint_memory.rs
@@ -153,7 +153,7 @@ impl<USB: UsbPeripheral> EndpointMemoryAllocator<USB> {
         }
 
         let mut used = self.total_rx_buffer_size_words() as usize + 30;
-        for sz in &self.tx_fifo_size_words {
+        for sz in &self.tx_fifo_size_words[0..ep_number] {
             used += core::cmp::max(*sz as usize, 16);
         }
         used -= 16;


### PR DESCRIPTION
Note: this is a `WIP` but wanted to put it out there for feedback sooner rather than later. _Maintainers please feel free to close this PR if you'd prefer not to have it sitting open_

Depends on rust-embedded-community/usb-device#60 for upstream support in `usb-device`.

## Significant changes

1. The core requires that isochronous `IN` transfers set the even/odd frame bit in `DIEPCTL` before transmitting.
2. In the event of an incomplete isochronous IN transfer, indicated by the `IISOIXFRM` interrupt, we must follow the procedure documented in the reference manual to reset the endpoint.

This has only been tested so far on two devices, `F411` and `F446`. The former was running in FS, the latter in HS. I've only used it for very small transfers to support USB Audio Class 2 feedback channels pumping a single floating point value back to the host each frame. It *does work* for that use case at least 😄 

## Remaining work

- [ ] test isochronous OUT transfers (it's possible to split this PR to support only `IN` to get it merged first)
- [ ] get agreement in `usb-device` on how to implement & test isochronous endpoints to get rust-embedded-community/usb-device#60 merged

