### PR TITLE
Add support for GD32VF103 chips [rebase]

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -108,7 +108,7 @@ impl<USB: UsbPeripheral> UsbBus<USB> {
         }
     }
 
-    fn deconfigure_all(&self, cs: &CriticalSection) {
+    fn deconfigure_all(&self, cs: &CriticalSection, core_id: u32) {
         let regs = self.regs.borrow(cs);
 
         // disable interrupts
@@ -122,7 +122,7 @@ impl<USB: UsbPeripheral> UsbBus<USB> {
 
         for ep in &self.allocator.endpoints_out {
             if let Some(ep) = ep {
-                ep.deconfigure(cs);
+                ep.deconfigure(cs, core_id);
             }
         }
     }
@@ -586,7 +586,7 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
             if reset != 0 {
                 write_reg!(otg_global, regs.global(), GINTSTS, USBRST: 1);
 
-                self.deconfigure_all(cs);
+                self.deconfigure_all(cs, core_id);
 
                 // Flush RX
                 modify_reg!(otg_global, regs.global(), GRSTCTL, RXFFLSH: 1);

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -449,7 +449,8 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                     //modify_reg!(otg_global, regs.global, GCCFG, NOVBUSSENS: 1);
                     modify_reg!(otg_global, regs.global(), GCCFG, |r| r | (1 << 21));
 
-                    modify_reg!(otg_global, regs.global(), GCCFG, VBUSASEN: 0, VBUSBSEN: 0, SOFOUTEN: 0);
+                    // VBUSBSEN=1 is required for GD32VF103
+                    modify_reg!(otg_global, regs.global(), GCCFG, VBUSASEN: 0, VBUSBSEN: 1, SOFOUTEN: 0);
                 }
                 0x0000_2000 | 0x0000_2100 | 0x0000_2300 | 0x0000_3000 | 0x0000_3100 => {
                     // F446-like chips have the GCCFG.VBDEN bit with the opposite meaning

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -189,15 +189,18 @@ impl EndpointOut {
         }
     }
 
-    pub fn deconfigure(&self, _cs: &CriticalSection) {
+    pub fn deconfigure(&self, _cs: &CriticalSection, core_id: u32) {
         let regs = self.usb.endpoint_out(self.index() as usize);
 
-        // deactivating endpoint
-        modify_reg!(endpoint_out, regs, DOEPCTL, USBAEP: 0);
+        // GD32VF103 doesn't support endpoint deactivation after reset, so skip this.
+        if core_id > 0x0000_1000 {
+            // deactivating endpoint
+            modify_reg!(endpoint_out, regs, DOEPCTL, USBAEP: 0);
 
-        // disabling endpoint
-        if read_reg!(endpoint_out, regs, DOEPCTL, EPENA) != 0 && self.index() != 0 {
-            modify_reg!(endpoint_out, regs, DOEPCTL, EPDIS: 1)
+            // disabling endpoint
+            if read_reg!(endpoint_out, regs, DOEPCTL, EPENA) != 0 && self.index() != 0 {
+                modify_reg!(endpoint_out, regs, DOEPCTL, EPDIS: 1)
+            }
         }
 
         // clean EP interrupts


### PR DESCRIPTION
This is rebase of original PR #25.

I tested it with test class example.
Also I tested CDC ACM made using `usbd_serial` crate ([usb-otg-workspace#7](https://github.com/Disasm/usb-otg-workspace/pull/7))