### PR TITLE
Quick fix for ISO endpoints

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -678,6 +678,19 @@ impl<USB: UsbPeripheral> usb_device::bus::UsbBus for UsbBus<USB> {
                         }
                     }
 
+                    if status == 0x02 {
+                        if let Some(ep) = &self.allocator.endpoints_out[epnum as usize] {
+                            // toggle (micro)frame number odd/even bit for ISO transactions if interval is 1
+                            if ep.descriptor().ep_type == EndpointType::Isochronous && ep.descriptor().interval == 1 {
+                                let ep = regs.endpoint_out(epnum as usize);
+                                let odd = read_reg!(endpoint_out, ep, DOEPCTL, EONUM_DPID);
+                                modify_reg!(endpoint_out, ep, DOEPCTL,
+                                    SD0PID_SEVNFRM: odd as u32,
+                                    SODDFRM: !odd as u32);
+                            }
+                        }
+                    }
+
                     if status == 0x02 || status == 0x06 {
                         if let Some(ep) = &self.allocator.endpoints_out[epnum as usize] {
                             let mut buffer = ep.buffer.borrow(cs).borrow_mut();


### PR DESCRIPTION
This is a quick fix for isochronous (ISO)  endpoints that does not require changes on the `usb-device`.

There is already  PR #29 for ISO endpoints pending, which seems to aim at a more sophisticated solution. I propose to integrate the present PR as an intermediate solution.

Successfully tested on STM32F446 on FS using a Linux host with different values for endpoint `bInterval`. Got reports on successful experiments on HS.

Primary use case: audio streaming according to USB Audio Device Class, Release 1.0