### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v0.5.0] - 2025-10-10
 
 ### Added
 
@@ -14,8 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-* Use `critical-section` crate for critical sections.
-* Replaced bundled RAL macros with `ral-registers`
+* Use `critical-section` crate for critical sections (#28)
+* Replaced bundled RAL macros with `ral-registers` (#45)
 
 
 ## [v0.4.0] - 2023-11-18
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
-[Unreleased]: https://github.com/stm32-rs/synopsys-usb-otg/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/stm32-rs/synopsys-usb-otg/compare/v0.5.0...HEAD
+[0.4.0]: https://github.com/stm32-rs/synopsys-usb-otg/compare/v0.5.0...v0.4.0
 [0.4.0]: https://github.com/stm32-rs/synopsys-usb-otg/compare/v0.4.0...v0.3.2
 [0.3.2]: https://github.com/stm32-rs/synopsys-usb-otg/compare/v0.3.2...v0.3.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synopsys-usb-otg"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Vadim Kaushan <admin@disasm.info>"]
 description = "'usb-device' implementation for Synopsys USB OTG IP cores"
 edition = "2018"


### PR DESCRIPTION
Known issues:
* https://github.com/stm32-rs/synopsys-usb-otg/issues/53 (new)
* https://github.com/stm32-rs/synopsys-usb-otg/issues/54 (new)
* https://github.com/rust-embedded-community/usb-device/issues/166, https://github.com/stm32-rs/synopsys-usb-otg/issues/43
* https://github.com/stm32-rs/synopsys-usb-otg/issues/44
* https://github.com/stm32-rs/synopsys-usb-otg/issues/42

Overall, there is one regression that shouldn't affect normal usage of the devices, and one issue related to incomplete support of GD32VF103 chips. Since GD32 support is long awaited, I'm leaning towards creating a release and addressing the issues in one of the following releases.